### PR TITLE
Add Purescript-Run example

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,8 @@
     "purescript-heterogeneous": "^0.2.0",
     "purescript-variant": "^5.1.0",
     "purescript-matryoshka": "^0.4.0",
-    "purescript-generics-rep": "^6.0.0"
+    "purescript-generics-rep": "^6.0.0",
+    "purescript-run": "^2.0.0"
   },
   "devDependencies": {
     "purescript-psci-support": "^4.0.0"

--- a/src/ADT9.purs
+++ b/src/ADT9.purs
@@ -1,0 +1,54 @@
+module ADT9 where
+
+import Prelude hiding (add)
+
+import Data.Either (Either(..))
+import Data.Functor.Variant (VariantF, FProxy, on, case_)
+import Data.Symbol (SProxy(..))
+import Effect (Effect)
+import Effect.Class.Console (log)
+import Effect.Console (logShow)
+import Run (Run, lift, peel)
+import Type.Row (type (+))
+
+data AddF a = AddF a a
+
+derive instance functorAddF :: Functor AddF
+
+_add :: SProxy "add"
+_add = SProxy
+
+type ADD r = (add :: FProxy AddF | r)
+
+type Expr r = Run (ADD + r)
+
+-- Smart Constructors
+
+lit :: forall r a. a -> Run r a
+lit n = pure n
+
+add :: forall r a
+     . Run (ADD + r) a
+    -> Run (ADD + r) a
+    -> Run (ADD + r) a
+add x y = join $ lift _add (AddF x y)
+
+iter :: forall r a. (VariantF r a -> a) -> Run r a -> a
+iter k = go where
+  go m = case peel m of
+    Left f -> k (go <$> f)
+    Right a -> a
+
+expr :: forall r. Expr r Number
+expr = add (lit 10.0) (lit 20.0)
+
+eval :: forall r. Expr r Number -> Number
+eval = iter (case_ # on _add evalAlgebra)
+  where
+    evalAlgebra (AddF a b) = a + b
+
+main :: Effect Unit
+main = do
+  log "---- ADT9 ----"
+  logShow $ eval expr
+  log "--------------"

--- a/src/Main.purs
+++ b/src/Main.purs
@@ -10,6 +10,7 @@ import ADT5 as ADT5
 import ADT6 as ADT6
 import ADT7 as ADT7
 import ADT8 as ADT8
+import ADT9 as ADT9
 import Effect (Effect)
 
 main :: Effect Unit
@@ -22,3 +23,4 @@ main = do
   ADT6.main
   ADT7.main
   ADT8.main
+  ADT9.main


### PR DESCRIPTION
I basically wrote my code using your style (or at least tried to) and got this.

However, **the following code does not compile** because of the type signature of `eval`:
```purescript
eval :: forall r. Expr r Number -> Number
```
The types do not match:
```
Could not match type
                        
    ( add :: FProxy AddF
    )                   
                        
  with type
                        
    ( add :: FProxy AddF
    | r6                
    )                   
                        

while solving type class constraint
                                    
  Prim.Row.Cons "add"               
                (FProxy AddF)       
                ()                  
                ( add :: FProxy AddF
                | r6                
                ) 
```

I did not get this error in my version of it because, I believe, I delegate the algebra's definition to the caller, which forces the `r` to be an empty row, `()`, due to `case_`'s type signature:
```purescript
eval :: forall r a b
      . ((VariantF () a -> b) -> VariantF r Int -> Int)
     -> Run r Int
     -> Int
eval algebra = iter (case_ # algebra)
```
If I change this PR's eval's Expr's `r` above to `()`, the code compiles. Any ideas for how I could fix the problem?